### PR TITLE
Use VS Code theme CSS variables to style cache properties

### DIFF
--- a/webview-src/AccessKeyDropdown.tsx
+++ b/webview-src/AccessKeyDropdown.tsx
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import {
     GroupedList,
     IGroup,
@@ -6,11 +9,12 @@ import {
     IGroupRenderProps,
     IRenderFunction,
     IStyle,
+    Label,
     SelectionMode,
 } from '@fluentui/react/lib/';
 import * as React from 'react';
 import { CopyableTextField } from './CopyableTextField';
-import { StrPrimaryAccessKey, StrPrimaryConnectionStr, StrAccessKeys } from './Strings';
+import { StrPrimaryAccessKey, StrPrimaryConnectionStr, StrAccessKeys, StrPrimary } from './Strings';
 
 interface Props {
     accessKey?: string;
@@ -43,8 +47,25 @@ const onRenderHeader: IRenderFunction<IGroupHeaderProps> = (
         return null;
     }
 
+    // Make entire header togglable
+    const onToggleSelectGroup = (): void => {
+        if (headerProps?.onToggleCollapse && headerProps?.group) {
+            headerProps.onToggleCollapse(headerProps.group);
+        }
+    };
+
+    // Hide header count
     const headerCountStyle: IStyle = { display: 'none' };
-    return <span>{defaultRender({ ...headerProps, styles: { headerCount: headerCountStyle } })}</span>;
+
+    return (
+        <span>
+            {defaultRender({
+                ...headerProps,
+                styles: { headerCount: headerCountStyle },
+                onToggleSelectGroup: onToggleSelectGroup,
+            })}
+        </span>
+    );
 };
 
 export function AccessKeyDropdown(props: Props): React.ReactElement | null {
@@ -58,7 +79,7 @@ export function AccessKeyDropdown(props: Props): React.ReactElement | null {
         {
             count: 1,
             key: 'group',
-            name: StrAccessKeys,
+            name: StrPrimary,
             startIndex: 0,
             isCollapsed: true,
         },
@@ -69,6 +90,7 @@ export function AccessKeyDropdown(props: Props): React.ReactElement | null {
 
     return (
         <div>
+            <Label>{StrAccessKeys}</Label>
             <GroupedList
                 items={items}
                 onRenderCell={onRenderCell}

--- a/webview-src/CollapsibleList.tsx
+++ b/webview-src/CollapsibleList.tsx
@@ -1,7 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { GroupedList, Label, SelectionMode } from '@fluentui/react/lib/';
+import {
+    GroupedList,
+    Label,
+    SelectionMode,
+    IRenderFunction,
+    IGroupDividerProps,
+    IGroupHeaderProps,
+    IGroupRenderProps,
+} from '@fluentui/react/lib/';
 import * as React from 'react';
 import { CopyableTextField } from './CopyableTextField';
 
@@ -13,9 +21,34 @@ interface Props {
 
 const onRenderCell = (nestingDepth?: number, item?: string, itemIndex?: number): JSX.Element => {
     return (
-        <div style={{ marginLeft: '36px', marginTop: '8px' }}>
+        <div style={{ marginLeft: '48px', marginTop: '8px' }}>
             <CopyableTextField id="hostName" value={item} />
         </div>
+    );
+};
+
+const onRenderHeader: IRenderFunction<IGroupHeaderProps> = (
+    headerProps?: IGroupDividerProps,
+    defaultRender?: IRenderFunction<IGroupHeaderProps>
+) => {
+    if (!defaultRender) {
+        return null;
+    }
+
+    // Make entire header togglable
+    const onToggleSelectGroup = (): void => {
+        if (headerProps?.onToggleCollapse && headerProps?.group) {
+            headerProps.onToggleCollapse(headerProps.group);
+        }
+    };
+
+    return (
+        <span>
+            {defaultRender({
+                ...headerProps,
+                onToggleSelectGroup: onToggleSelectGroup,
+            })}
+        </span>
     );
 };
 
@@ -33,6 +66,9 @@ export function CollapsibleList(props: Props): React.ReactElement | null {
             isCollapsed: true,
         },
     ];
+    const groupProps: IGroupRenderProps = {
+        onRenderHeader,
+    };
 
     return (
         <div>
@@ -41,6 +77,7 @@ export function CollapsibleList(props: Props): React.ReactElement | null {
                 items={props.values}
                 onRenderCell={onRenderCell}
                 groups={group}
+                groupProps={groupProps}
                 selectionMode={SelectionMode.none}
                 compact={true}
             />

--- a/webview-src/CopyableTextField.tsx
+++ b/webview-src/CopyableTextField.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ITooltipHostStyles, Stack, TextField, TooltipDelay, TooltipHost } from '@fluentui/react/lib/';
+import { ITooltipHostStyles, Stack, TextField, TooltipDelay, TooltipHost, IStackTokens } from '@fluentui/react/lib/';
 import * as React from 'react';
 import { CopyButton } from './CopyButton';
 import { StrCopied, StrCopyToClipboard } from './Strings';
@@ -19,6 +19,9 @@ interface Props {
 
 const tooltipProps = { gapSpace: 0 };
 const tooltipStyles: Partial<ITooltipHostStyles> = { root: { display: 'inline-block' } };
+const stackTokens: IStackTokens = {
+    childrenGap: 5,
+};
 
 export class CopyableTextField extends React.Component<Props, State> {
     state = {
@@ -50,7 +53,7 @@ export class CopyableTextField extends React.Component<Props, State> {
         const tooltipText = this.state.showClicked ? StrCopied : StrCopyToClipboard;
 
         return (
-            <Stack horizontal>
+            <Stack horizontal tokens={stackTokens}>
                 <Stack.Item grow align="end">
                     <TextField label={this.props.label} readOnly value={value} />
                 </Stack.Item>

--- a/webview-src/Index.tsx
+++ b/webview-src/Index.tsx
@@ -74,13 +74,14 @@ class Index extends React.Component<{}, State> {
                     <CopyableTextField id="nonSslPort" label={Strings.StrNonSslPort} value={nonSslPort} />
                     <CopyableTextField id="sslPort" label={Strings.StrSslPort} value={redisResource.sslPort} />
                     <CopyableTextField id="resourceId" label={Strings.StrResourceId} value={redisResource.resourceId} />
+                    <CollapsibleList
+                        label={Strings.StrGeoReplication}
+                        groupName={Strings.StrLinkedServers}
+                        values={redisResource.linkedServers}
+                    />
                     <AccessKeyDropdown accessKey={accessKey} connectionString={connectionString} />
                 </div>
-                <CollapsibleList
-                    label={Strings.StrGeoReplication}
-                    groupName={Strings.StrLinkedServers}
-                    values={redisResource.linkedServers}
-                />
+
                 <GeneralPropertyLabel label={Strings.StrSku} value={redisResource.sku} />
                 <GeneralPropertyLabel label={Strings.StrLocation} value={redisResource.location} />
                 <GeneralPropertyLabel label={Strings.StrRedisVersion} value={redisResource.redisVersion} />

--- a/webview-src/Strings.ts
+++ b/webview-src/Strings.ts
@@ -9,6 +9,7 @@ export const StrNonSslPort = 'Non-SSL port';
 export const StrSslPort = 'SSL port';
 export const StrResourceId = 'Resource ID';
 export const StrAccessKeys = 'Access keys';
+export const StrPrimary = 'Primary';
 export const StrPrimaryAccessKey = 'Primary access key';
 export const StrPrimaryConnectionStr = 'Primary connection string (StackExchange.Redis)';
 

--- a/webview-src/styles.css
+++ b/webview-src/styles.css
@@ -1,10 +1,44 @@
 /* Copyright (c) Microsoft Corporation.
    Licensed under the MIT License. */
 
+.container {
+    margin-bottom: 12px;
+}
+
 .indented {
     margin-left: 8px;
 }
 
-.container {
-    margin-bottom: 12px;
+.ms-Label {
+    color: var(--vscode-editor-foreground);
+}
+
+.ms-TextField-field {
+    color: var(--vscode-editor-foreground);
+    background-color: var(--vscode-editor-background);
+}
+
+.ms-TextField-fieldGroup {
+    border-color: var(--vscode-editor-foreground);
+}
+
+.ms-TextField-fieldGroup:hover {
+    border-color: var(--vscode-button-hoverBackground);
+}
+
+.ms-GroupHeader-title {
+    cursor: initial;
+}
+
+.ms-GroupHeader:hover {
+    color: var(--vscode-editor-foreground);
+    background-color: var(--vscode-breadcrumbPicker-background);
+}
+
+.ms-GroupHeader-expand {
+    color: var(--vscode-editor-foreground);
+}
+
+.ms-GroupHeader-expand:hover {
+    background-color: var(--vscode-breadcrumbPicker-background);
 }


### PR DESCRIPTION
Fixes #2 

Now the colours used for the Cache Properties are based off of the current theme.
Also added a header for **Access keys**.

Screenshot:
![Untitled](https://user-images.githubusercontent.com/9157833/87986880-b9952880-caab-11ea-88a5-6b81a6315c44.png)
