### PR TITLE
Update VSCE and use githubBranch flag to point to main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9564,9 +9564,9 @@
             "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
         },
         "vsce": {
-            "version": "1.77.0",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.77.0.tgz",
-            "integrity": "sha512-8vOTCI3jGmOm0JJFu/BMAbqxpaSuka4S3hV9E6K5aWBUsDM1SGFExkIxHblnsI8sls43xP61DHorYT+K0F+GFA==",
+            "version": "1.78.0",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.78.0.tgz",
+            "integrity": "sha512-4CIUTwhcU+RlQDW+GNKO6AhQ7aZJCzDA9A9r7j262LTd+NoCowE/bRV2pCII9peXMowIumTtk+Sz/pQ5Ng0VJQ==",
             "dev": true,
             "requires": {
                 "azure-devops-node-api": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
         "pretest": "npm run compile && npm run lint",
         "test": "node ./out/src/test/runTest.js",
         "watch": "webpack --mode development --watch --info-verbosity verbose",
-        "package": "vsce package --baseImagesUrl https://github.com/microsoft/vscode-azurecache/raw/main/",
-        "publish": "vsce publish --baseImagesUrl https://github.com/microsoft/vscode-azurecache/raw/main/"
+        "package": "vsce package --githubBranch main",
+        "publish": "vsce publish --githubBranch main"
     },
     "activationEvents": [
         "onView:azureCache"
@@ -242,7 +242,7 @@
         "ts-loader": "^7.0.5",
         "ts-sinon": "^1.2.0",
         "typescript": "^3.9.7",
-        "vsce": "^1.77.0",
+        "vsce": "^1.78.0",
         "vscode-test": "^1.4.0",
         "webpack": "^4.44.1",
         "webpack-cli": "^3.3.12"


### PR DESCRIPTION
Update VSCE to `1.78.0` which supports a new `githubBranch` flag and fixes a bug related to `mailto` link parsing.