### PR TITLE
Support primary and secondary access keys and connection strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,9 +90,24 @@
                     "group": "5_portal"
                 },
                 {
-                    "command": "azureCache.copyConnectionString",
+                    "command": "azureCache.copyPrimaryAccessKey",
                     "when": "view == azureCache && viewItem =~ /redisCache/",
-                    "group": "5_portal"
+                    "group": "3_accesskey"
+                },
+                {
+                    "command": "azureCache.copySecondaryAccessKey",
+                    "when": "view == azureCache && viewItem =~ /redisCache/",
+                    "group": "3_accesskey"
+                },
+                {
+                    "command": "azureCache.copyPrimaryConnectionString",
+                    "when": "view == azureCache && viewItem =~ /redisCache/",
+                    "group": "4_connectkey"
+                },
+                {
+                    "command": "azureCache.copySecondaryConnectionString",
+                    "when": "view == azureCache && viewItem =~ /redisCache/",
+                    "group": "4_connectkey"
                 }
             ],
             "commandPalette": [
@@ -117,7 +132,19 @@
                     "when": "never"
                 },
                 {
-                    "command": "azureCache.copyConnectionString",
+                    "command": "azureCache.copyPrimaryAccessKey",
+                    "when": "never"
+                },
+                {
+                    "command": "azureCache.copySecondaryAccessKey",
+                    "when": "never"
+                },
+                {
+                    "command": "azureCache.copyPrimaryConnectionString",
+                    "when": "never"
+                },
+                {
+                    "command": "azureCache.copySecondaryConnectionString",
                     "when": "never"
                 },
                 {
@@ -176,8 +203,23 @@
                 "category": "Azure Cache"
             },
             {
-                "command": "azureCache.copyConnectionString",
-                "title": "Copy connection string",
+                "command": "azureCache.copyPrimaryAccessKey",
+                "title": "Copy primary access key",
+                "category": "Azure Cache"
+            },
+            {
+                "command": "azureCache.copySecondaryAccessKey",
+                "title": "Copy secondary access key",
+                "category": "Azure Cache"
+            },
+            {
+                "command": "azureCache.copyPrimaryConnectionString",
+                "title": "Copy primary connection string",
+                "category": "Azure Cache"
+            },
+            {
+                "command": "azureCache.copySecondaryConnectionString",
+                "title": "Copy secondary connection string",
                 "category": "Azure Cache"
             },
             {

--- a/src-shared/ParsedAccessKeys.ts
+++ b/src-shared/ParsedAccessKeys.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Represents primary and secondary access keys.
+ */
+export interface ParsedAccessKeys {
+    /**
+     * Primary access key.
+     */
+    primaryKey: string;
+    /**
+     * Secondary access key.
+     */
+    secondaryKey: string;
+}

--- a/src-shared/ParsedConnectionStrings.ts
+++ b/src-shared/ParsedConnectionStrings.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Represents primary and secondary connection strings.
+ */
+export interface ParsedConnectionStrings {
+    /**
+     * Primary connection string.
+     */
+    primaryConnectionString: string;
+    /**
+     * Secondary connection string.
+     */
+    secondaryConnectionString: string;
+}

--- a/src-shared/ParsedRedisResource.ts
+++ b/src-shared/ParsedRedisResource.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { ParsedAccessKeys } from './ParsedAccessKeys';
+
 /**
  * Interface that guarentees non-null properties of a RedisResource.
  *
@@ -69,7 +71,7 @@ export interface ParsedRedisResource {
      */
     linkedServers: string[];
     /**
-     * Access key for the resource. Promise may resolve with undefined if user does not have write access to resource.
+     * Access keys for the resource. Promise may resolve with undefined if user does not have write access to resource.
      */
-    accessKey: Promise<string | undefined>;
+    accessKeys: Promise<ParsedAccessKeys | undefined>;
 }

--- a/src-shared/WebviewCommand.ts
+++ b/src-shared/WebviewCommand.ts
@@ -6,7 +6,7 @@ export enum WebviewCommand {
     View = 'view',
     // Cache Properties
     ParsedRedisResource = 'parsedRedisResource',
-    AccessKey = 'accessKey',
+    AccessKeys = 'accessKeys',
     ConnectionString = 'connectionString',
     CopyText = 'copyText',
     // Data viewer

--- a/src-webview/Strings.ts
+++ b/src-webview/Strings.ts
@@ -12,6 +12,9 @@ export const StrAccessKeys = 'Access keys';
 export const StrPrimary = 'Primary';
 export const StrPrimaryAccessKey = 'Primary access key';
 export const StrPrimaryConnectionStr = 'Primary connection string (StackExchange.Redis)';
+export const StrSecondary = 'Secondary';
+export const StrSecondaryAccessKey = 'Secondary access key';
+export const StrSecondaryConnectionStr = 'Secondary connection string (StackExchange.Redis)';
 
 export const StrGeoReplication = 'Geo-replication';
 export const StrLinkedServers = 'Linked servers';

--- a/src-webview/properties/CacheProperties.tsx
+++ b/src-webview/properties/CacheProperties.tsx
@@ -12,11 +12,11 @@ import { CollapsibleList } from './CollapsibleList';
 import { CopyableTextField } from './CopyableTextField';
 import { GeneralPropertyLabel } from './GeneralPropertyLabel';
 import './styles.css';
+import { ParsedAccessKeys } from '../../src-shared/ParsedAccessKeys';
 
 interface State {
     redisResource?: ParsedRedisResource;
-    accessKey?: string;
-    connectionString?: string;
+    accessKeys?: ParsedAccessKeys;
 }
 
 export class CacheProperties extends React.Component<{}, State> {
@@ -24,8 +24,7 @@ export class CacheProperties extends React.Component<{}, State> {
         super(props);
         this.state = {
             redisResource: undefined,
-            accessKey: undefined,
-            connectionString: undefined,
+            accessKeys: undefined,
         };
     }
 
@@ -36,12 +35,9 @@ export class CacheProperties extends React.Component<{}, State> {
             if (message.command === WebviewCommand.ParsedRedisResource) {
                 const parsedRedisResource = message.value as ParsedRedisResource;
                 this.setState({ redisResource: parsedRedisResource });
-            } else if (message.command === WebviewCommand.AccessKey) {
-                const accessKey = message.value as string | undefined;
-                this.setState({ accessKey });
-            } else if (message.command === WebviewCommand.ConnectionString) {
-                const connectionString = message.value as string | undefined;
-                this.setState({ connectionString });
+            } else if (message.command === WebviewCommand.AccessKeys) {
+                const accessKeys = message.value as ParsedAccessKeys | undefined;
+                this.setState({ accessKeys });
             }
         });
     }
@@ -51,7 +47,7 @@ export class CacheProperties extends React.Component<{}, State> {
             return null;
         }
 
-        const { redisResource, accessKey, connectionString } = this.state;
+        const { redisResource, accessKeys } = this.state;
         const nonSslPort = redisResource.enableNonSslPort ? redisResource.port : Strings.StrDisabled;
         const shardCountLabel =
             redisResource.shardCount > 0 ? (
@@ -73,7 +69,7 @@ export class CacheProperties extends React.Component<{}, State> {
                         groupName={Strings.StrLinkedServers}
                         values={redisResource.linkedServers}
                     />
-                    <AccessKeyDropdown accessKey={accessKey} connectionString={connectionString} />
+                    <AccessKeyDropdown parsedRedisResource={redisResource} parsedAccessKeys={accessKeys} />
                 </div>
 
                 <GeneralPropertyLabel label={Strings.StrSku} value={redisResource.sku} />

--- a/src/Strings.ts
+++ b/src/Strings.ts
@@ -15,7 +15,7 @@ export const StrPromptKeyFilter = 'Provide a key filter expression';
 export const StrPromptHashFieldFilter = 'Provide a hash field filter expression';
 export const StrPromptRefreshCache = 'Try refreshing the cache in the side bar.';
 
-export const ErrorMissingKeys = 'Missing access keys';
+export const ErrorAccessKeys = 'Could not retrieve access keys';
 export const ErrorConnectionString = 'Could not retrieve connection string';
 export const ErrorMissingNodeClient = 'Could not find node client';
 export const ErrorMissingResourceId = 'Missing resource ID';

--- a/src/clients/RedisClient.ts
+++ b/src/clients/RedisClient.ts
@@ -136,11 +136,12 @@ export class RedisClient {
                     }
                 }
 
-                const { accessKey, cluster, hostName, port, sslPort, provisioningState } = parsedRedisResource;
-                const password = await accessKey;
-                if (typeof password === 'undefined') {
+                const { accessKeys, cluster, hostName, port, sslPort, provisioningState } = parsedRedisResource;
+                const parsedAccessKeys = await accessKeys;
+                if (typeof parsedAccessKeys === 'undefined') {
                     throw new Error(Strings.ErrorReadAccessKey);
                 }
+                const password = parsedAccessKeys.primaryKey;
 
                 if (provisioningState !== 'Succeeded') {
                     vscode.window.showWarningMessage(`${Strings.StrCurrentProvStateIs}: ${provisioningState}`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -125,7 +125,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     );
 
     registerCommand(
-        'azureCache.copyConnectionString',
+        'azureCache.copyPrimaryAccessKey',
         async (actionContext: IActionContext, treeItem?: AzureCacheItem) => {
             if (!treeItem) {
                 treeItem = (await ExtVars.treeDataProvider.showTreeItemPicker(
@@ -134,7 +134,64 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                 )) as AzureCacheItem;
             }
 
-            const connectionString = await treeItem.getConnectionString();
+            const accessKey = await treeItem.getPrimaryAccessKey();
+            if (accessKey) {
+                vscode.env.clipboard.writeText(accessKey);
+            } else {
+                vscode.window.showErrorMessage(Strings.ErrorAccessKeys);
+            }
+        }
+    );
+
+    registerCommand(
+        'azureCache.copySecondaryAccessKey',
+        async (actionContext: IActionContext, treeItem?: AzureCacheItem) => {
+            if (!treeItem) {
+                treeItem = (await ExtVars.treeDataProvider.showTreeItemPicker(
+                    AzureCacheItem.contextValue,
+                    actionContext
+                )) as AzureCacheItem;
+            }
+
+            const accessKey = await treeItem.getSecondaryAccessKey();
+            if (accessKey) {
+                vscode.env.clipboard.writeText(accessKey);
+            } else {
+                vscode.window.showErrorMessage(Strings.ErrorAccessKeys);
+            }
+        }
+    );
+
+    registerCommand(
+        'azureCache.copyPrimaryConnectionString',
+        async (actionContext: IActionContext, treeItem?: AzureCacheItem) => {
+            if (!treeItem) {
+                treeItem = (await ExtVars.treeDataProvider.showTreeItemPicker(
+                    AzureCacheItem.contextValue,
+                    actionContext
+                )) as AzureCacheItem;
+            }
+
+            const connectionString = await treeItem.getPrimaryConnectionString();
+            if (connectionString) {
+                vscode.env.clipboard.writeText(connectionString);
+            } else {
+                vscode.window.showErrorMessage(Strings.ErrorConnectionString);
+            }
+        }
+    );
+
+    registerCommand(
+        'azureCache.copySecondaryConnectionString',
+        async (actionContext: IActionContext, treeItem?: AzureCacheItem) => {
+            if (!treeItem) {
+                treeItem = (await ExtVars.treeDataProvider.showTreeItemPicker(
+                    AzureCacheItem.contextValue,
+                    actionContext
+                )) as AzureCacheItem;
+            }
+
+            const connectionString = await treeItem.getSecondaryConnectionString();
             if (connectionString) {
                 vscode.env.clipboard.writeText(connectionString);
             } else {

--- a/src/test/CollectionItems.test.ts
+++ b/src/test/CollectionItems.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ParsedRedisResource } from '../../src-shared/ParsedRedisResource';
 import { RedisClient } from '../clients/RedisClient';
 import { RedisResourceClient } from '../clients/RedisResourceClient';
 import { AzureCacheItem } from '../tree/azure/AzureCacheItem';
@@ -12,6 +11,7 @@ import { RedisListItem } from '../tree/redis/RedisListItem';
 import { RedisSetItem } from '../tree/redis/RedisSetItem';
 import { RedisZSetItem } from '../tree/redis/RedisZSetItem';
 import { TestRedisClient } from './clients/TestRedisClient';
+import * as Shared from './Shared';
 import sinon = require('sinon');
 import assert = require('assert');
 
@@ -26,30 +26,10 @@ describe('CollectionItems', () => {
         sandbox.restore();
     });
 
-    const sampleParsedRedisResource: ParsedRedisResource = {
-        resourceId:
-            '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res-group/providers/Microsoft.Cache/Redis/my-cache',
-        subscriptionId: '00000000-0000-0000-0000-000000000000',
-        resourceGroup: 'res-group',
-        name: 'my-cache',
-        hostName: 'mycache.net',
-        enableNonSslPort: true,
-        port: 6379,
-        sslPort: 6380,
-        sku: 'Premium P1',
-        location: 'West US',
-        redisVersion: 'Unknown',
-        provisioningState: 'Unknown',
-        cluster: false,
-        shardCount: 0,
-        linkedServers: [],
-        accessKey: Promise.resolve('key'),
-    };
-
     const cacheItem = new AzureCacheItem(
         {} as AzureSubscriptionTreeItem,
         {} as RedisResourceClient,
-        sampleParsedRedisResource
+        Shared.resourceWithKey
     );
     const testDb = new RedisDbItem(cacheItem, 0);
 

--- a/src/test/CollectionItems.test.ts
+++ b/src/test/CollectionItems.test.ts
@@ -29,7 +29,7 @@ describe('CollectionItems', () => {
     const cacheItem = new AzureCacheItem(
         {} as AzureSubscriptionTreeItem,
         {} as RedisResourceClient,
-        Shared.resourceWithKey
+        Shared.createResourceWithKey()
     );
     const testDb = new RedisDbItem(cacheItem, 0);
 

--- a/src/test/KeyContentProvider.test.ts
+++ b/src/test/KeyContentProvider.test.ts
@@ -35,13 +35,13 @@ describe('KeyContentProvider', () => {
         sandbox.stub(RedisClient, 'connectToRedisResource').resolves(stubRedisClient);
 
         const keyContentProvider = new KeyContentProvider();
-        const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'string', 'mykey');
+        const uri = createKeyContentUri(Shared.createResourceWithKey(), 0, 'string', 'mykey');
         /**
          * Normally, calling showKey() will call vscode.workspace.openTextDocument, which will prompt VS Code to call
          * provideTextDocumentContent(), but since the tests run without the extension being activated, we call
          * provideTextDocumentContent() manually.
          */
-        keyContentProvider.showKey(Shared.resourceWithKey, 0, 'string', 'mykey');
+        keyContentProvider.showKey(Shared.createResourceWithKey(), 0, 'string', 'mykey');
         const value = await keyContentProvider.provideTextDocumentContent(uri);
         assert.strictEqual(value, 'myValue');
         // Calling it again should fail as the Redis resource client property is cleared
@@ -57,9 +57,9 @@ describe('KeyContentProvider', () => {
         sandbox.stub(RedisClient, 'connectToRedisResource').resolves(stubRedisClient);
 
         const keyContentProvider = new KeyContentProvider();
-        const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'list', 'mykey', '0');
+        const uri = createKeyContentUri(Shared.createResourceWithKey(), 0, 'list', 'mykey', '0');
 
-        keyContentProvider.showKey(Shared.resourceWithKey, 0, 'list', 'mykey');
+        keyContentProvider.showKey(Shared.createResourceWithKey(), 0, 'list', 'mykey');
         const value = await keyContentProvider.provideTextDocumentContent(uri);
 
         assert.strictEqual(value, 'myListValue');
@@ -77,8 +77,8 @@ describe('KeyContentProvider', () => {
 
         const keyContentProvider = new KeyContentProvider();
         // Leave out subkey parameter
-        const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'list', 'mykey');
-        keyContentProvider.showKey(Shared.resourceWithKey, 0, 'list', 'mykey');
+        const uri = createKeyContentUri(Shared.createResourceWithKey(), 0, 'list', 'mykey');
+        keyContentProvider.showKey(Shared.createResourceWithKey(), 0, 'list', 'mykey');
 
         assert.rejects(keyContentProvider.provideTextDocumentContent(uri), Error);
     });
@@ -91,8 +91,8 @@ describe('KeyContentProvider', () => {
         sandbox.stub(RedisClient, 'connectToRedisResource').resolves(stubRedisClient);
 
         const keyContentProvider = new KeyContentProvider();
-        const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'hash', 'mykey', 'hashfield');
-        keyContentProvider.showKey(Shared.resourceWithKey, 0, 'hash', 'mykey', 'hashValue', 'hashField');
+        const uri = createKeyContentUri(Shared.createResourceWithKey(), 0, 'hash', 'mykey', 'hashfield');
+        keyContentProvider.showKey(Shared.createResourceWithKey(), 0, 'hash', 'mykey', 'hashValue', 'hashField');
         const value = await keyContentProvider.provideTextDocumentContent(uri);
 
         assert.strictEqual(value, 'hashValue');
@@ -108,9 +108,9 @@ describe('KeyContentProvider', () => {
         sandbox.stub(RedisClient, 'connectToRedisResource').resolves(stubRedisClient);
 
         const keyContentProvider = new KeyContentProvider();
-        const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'hash', 'mykey', 'hashfield');
+        const uri = createKeyContentUri(Shared.createResourceWithKey(), 0, 'hash', 'mykey', 'hashfield');
         // Leave out hash item value
-        keyContentProvider.showKey(Shared.resourceWithKey, 0, 'hash', 'mykey');
+        keyContentProvider.showKey(Shared.createResourceWithKey(), 0, 'hash', 'mykey');
 
         assert.rejects(keyContentProvider.provideTextDocumentContent(uri), Error);
     });
@@ -123,8 +123,8 @@ describe('KeyContentProvider', () => {
         sandbox.stub(RedisClient, 'connectToRedisResource').resolves(stubRedisClient);
 
         const keyContentProvider = new KeyContentProvider();
-        const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'set', 'mykey', '0');
-        keyContentProvider.showKey(Shared.resourceWithKey, 0, 'set', 'mykey', 'setValue', '0');
+        const uri = createKeyContentUri(Shared.createResourceWithKey(), 0, 'set', 'mykey', '0');
+        keyContentProvider.showKey(Shared.createResourceWithKey(), 0, 'set', 'mykey', 'setValue', '0');
         const value = await keyContentProvider.provideTextDocumentContent(uri);
 
         assert.strictEqual(value, 'setValue');
@@ -140,9 +140,9 @@ describe('KeyContentProvider', () => {
         sandbox.stub(RedisClient, 'connectToRedisResource').resolves(stubRedisClient);
 
         const keyContentProvider = new KeyContentProvider();
-        const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'set', 'mykey', '0');
+        const uri = createKeyContentUri(Shared.createResourceWithKey(), 0, 'set', 'mykey', '0');
         // Leave out the set element value
-        keyContentProvider.showKey(Shared.resourceWithKey, 0, 'set', 'mykey');
+        keyContentProvider.showKey(Shared.createResourceWithKey(), 0, 'set', 'mykey');
 
         assert.rejects(keyContentProvider.provideTextDocumentContent(uri), Error);
     });
@@ -155,8 +155,8 @@ describe('KeyContentProvider', () => {
         sandbox.stub(RedisClient, 'connectToRedisResource').resolves(stubRedisClient);
 
         const keyContentProvider = new KeyContentProvider();
-        const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'zset', 'mykey', '-100', '0');
-        keyContentProvider.showKey(Shared.resourceWithKey, 0, 'zset', 'mykey', 'zsetValue', '-100', '0');
+        const uri = createKeyContentUri(Shared.createResourceWithKey(), 0, 'zset', 'mykey', '-100', '0');
+        keyContentProvider.showKey(Shared.createResourceWithKey(), 0, 'zset', 'mykey', 'zsetValue', '-100', '0');
         const value = await keyContentProvider.provideTextDocumentContent(uri);
 
         assert.strictEqual(value, 'zsetValue');
@@ -172,9 +172,9 @@ describe('KeyContentProvider', () => {
         sandbox.stub(RedisClient, 'connectToRedisResource').resolves(stubRedisClient);
 
         const keyContentProvider = new KeyContentProvider();
-        const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'zset', 'mykey', '-100');
+        const uri = createKeyContentUri(Shared.createResourceWithKey(), 0, 'zset', 'mykey', '-100');
         // Leave out the set element value
-        keyContentProvider.showKey(Shared.resourceWithKey, 0, 'zset', 'mykey');
+        keyContentProvider.showKey(Shared.createResourceWithKey(), 0, 'zset', 'mykey');
 
         assert.rejects(keyContentProvider.provideTextDocumentContent(uri), Error);
     });

--- a/src/test/KeyContentProvider.test.ts
+++ b/src/test/KeyContentProvider.test.ts
@@ -4,9 +4,9 @@
 import * as vscode from 'vscode';
 import { RedisClient } from '../clients/RedisClient';
 import { KeyContentProvider } from '../KeyContentProvider';
-import { ParsedRedisResource } from '../../src-shared/ParsedRedisResource';
 import { createKeyContentUri } from '../utils/UriUtils';
 import { TestRedisClient } from './clients/TestRedisClient';
+import * as Shared from './Shared';
 import sinon = require('sinon');
 import assert = require('assert');
 
@@ -25,25 +25,6 @@ describe('KeyContentProvider', () => {
     const validUri = vscode.Uri.parse(
         'azureCache:mycache.net/mykey?payload%3DeyJyZXNvdXJjZUlkIjoiL3N1YnNjcmlwdGlvbnMvMDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwL3Jlc291cmNlR3JvdXBzL3Jlcy1ncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0LkNhY2hlL1JlZGlzL215LWNhY2hlIiwiZGIiOjAsInR5cGUiOiJzdHJpbmciLCJrZXkiOiJteWtleSJ9'
     );
-    const sampleParsedRedisResource: ParsedRedisResource = {
-        resourceId:
-            '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res-group/providers/Microsoft.Cache/Redis/my-cache',
-        subscriptionId: '00000000-0000-0000-0000-000000000000',
-        resourceGroup: 'res-group',
-        name: 'my-cache',
-        hostName: 'mycache.net',
-        enableNonSslPort: true,
-        port: 6379,
-        sslPort: 6380,
-        sku: 'Premium P1',
-        location: 'West US',
-        redisVersion: 'Unknown',
-        provisioningState: 'Unknown',
-        cluster: false,
-        shardCount: 0,
-        linkedServers: [],
-        accessKey: Promise.resolve('key'),
-    };
 
     it('should return value of string key', async () => {
         // Setup stubs
@@ -54,13 +35,13 @@ describe('KeyContentProvider', () => {
         sandbox.stub(RedisClient, 'connectToRedisResource').resolves(stubRedisClient);
 
         const keyContentProvider = new KeyContentProvider();
-        const uri = createKeyContentUri(sampleParsedRedisResource, 0, 'string', 'mykey');
+        const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'string', 'mykey');
         /**
          * Normally, calling showKey() will call vscode.workspace.openTextDocument, which will prompt VS Code to call
          * provideTextDocumentContent(), but since the tests run without the extension being activated, we call
          * provideTextDocumentContent() manually.
          */
-        keyContentProvider.showKey(sampleParsedRedisResource, 0, 'string', 'mykey');
+        keyContentProvider.showKey(Shared.resourceWithKey, 0, 'string', 'mykey');
         const value = await keyContentProvider.provideTextDocumentContent(uri);
         assert.strictEqual(value, 'myValue');
         // Calling it again should fail as the Redis resource client property is cleared
@@ -76,9 +57,9 @@ describe('KeyContentProvider', () => {
         sandbox.stub(RedisClient, 'connectToRedisResource').resolves(stubRedisClient);
 
         const keyContentProvider = new KeyContentProvider();
-        const uri = createKeyContentUri(sampleParsedRedisResource, 0, 'list', 'mykey', '0');
+        const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'list', 'mykey', '0');
 
-        keyContentProvider.showKey(sampleParsedRedisResource, 0, 'list', 'mykey');
+        keyContentProvider.showKey(Shared.resourceWithKey, 0, 'list', 'mykey');
         const value = await keyContentProvider.provideTextDocumentContent(uri);
 
         assert.strictEqual(value, 'myListValue');
@@ -96,8 +77,8 @@ describe('KeyContentProvider', () => {
 
         const keyContentProvider = new KeyContentProvider();
         // Leave out subkey parameter
-        const uri = createKeyContentUri(sampleParsedRedisResource, 0, 'list', 'mykey');
-        keyContentProvider.showKey(sampleParsedRedisResource, 0, 'list', 'mykey');
+        const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'list', 'mykey');
+        keyContentProvider.showKey(Shared.resourceWithKey, 0, 'list', 'mykey');
 
         assert.rejects(keyContentProvider.provideTextDocumentContent(uri), Error);
     });
@@ -110,8 +91,8 @@ describe('KeyContentProvider', () => {
         sandbox.stub(RedisClient, 'connectToRedisResource').resolves(stubRedisClient);
 
         const keyContentProvider = new KeyContentProvider();
-        const uri = createKeyContentUri(sampleParsedRedisResource, 0, 'hash', 'mykey', 'hashfield');
-        keyContentProvider.showKey(sampleParsedRedisResource, 0, 'hash', 'mykey', 'hashValue', 'hashField');
+        const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'hash', 'mykey', 'hashfield');
+        keyContentProvider.showKey(Shared.resourceWithKey, 0, 'hash', 'mykey', 'hashValue', 'hashField');
         const value = await keyContentProvider.provideTextDocumentContent(uri);
 
         assert.strictEqual(value, 'hashValue');
@@ -127,9 +108,9 @@ describe('KeyContentProvider', () => {
         sandbox.stub(RedisClient, 'connectToRedisResource').resolves(stubRedisClient);
 
         const keyContentProvider = new KeyContentProvider();
-        const uri = createKeyContentUri(sampleParsedRedisResource, 0, 'hash', 'mykey', 'hashfield');
+        const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'hash', 'mykey', 'hashfield');
         // Leave out hash item value
-        keyContentProvider.showKey(sampleParsedRedisResource, 0, 'hash', 'mykey');
+        keyContentProvider.showKey(Shared.resourceWithKey, 0, 'hash', 'mykey');
 
         assert.rejects(keyContentProvider.provideTextDocumentContent(uri), Error);
     });
@@ -142,8 +123,8 @@ describe('KeyContentProvider', () => {
         sandbox.stub(RedisClient, 'connectToRedisResource').resolves(stubRedisClient);
 
         const keyContentProvider = new KeyContentProvider();
-        const uri = createKeyContentUri(sampleParsedRedisResource, 0, 'set', 'mykey', '0');
-        keyContentProvider.showKey(sampleParsedRedisResource, 0, 'set', 'mykey', 'setValue', '0');
+        const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'set', 'mykey', '0');
+        keyContentProvider.showKey(Shared.resourceWithKey, 0, 'set', 'mykey', 'setValue', '0');
         const value = await keyContentProvider.provideTextDocumentContent(uri);
 
         assert.strictEqual(value, 'setValue');
@@ -159,9 +140,9 @@ describe('KeyContentProvider', () => {
         sandbox.stub(RedisClient, 'connectToRedisResource').resolves(stubRedisClient);
 
         const keyContentProvider = new KeyContentProvider();
-        const uri = createKeyContentUri(sampleParsedRedisResource, 0, 'set', 'mykey', '0');
+        const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'set', 'mykey', '0');
         // Leave out the set element value
-        keyContentProvider.showKey(sampleParsedRedisResource, 0, 'set', 'mykey');
+        keyContentProvider.showKey(Shared.resourceWithKey, 0, 'set', 'mykey');
 
         assert.rejects(keyContentProvider.provideTextDocumentContent(uri), Error);
     });
@@ -174,8 +155,8 @@ describe('KeyContentProvider', () => {
         sandbox.stub(RedisClient, 'connectToRedisResource').resolves(stubRedisClient);
 
         const keyContentProvider = new KeyContentProvider();
-        const uri = createKeyContentUri(sampleParsedRedisResource, 0, 'zset', 'mykey', '-100', '0');
-        keyContentProvider.showKey(sampleParsedRedisResource, 0, 'zset', 'mykey', 'zsetValue', '-100', '0');
+        const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'zset', 'mykey', '-100', '0');
+        keyContentProvider.showKey(Shared.resourceWithKey, 0, 'zset', 'mykey', 'zsetValue', '-100', '0');
         const value = await keyContentProvider.provideTextDocumentContent(uri);
 
         assert.strictEqual(value, 'zsetValue');
@@ -191,9 +172,9 @@ describe('KeyContentProvider', () => {
         sandbox.stub(RedisClient, 'connectToRedisResource').resolves(stubRedisClient);
 
         const keyContentProvider = new KeyContentProvider();
-        const uri = createKeyContentUri(sampleParsedRedisResource, 0, 'zset', 'mykey', '-100');
+        const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'zset', 'mykey', '-100');
         // Leave out the set element value
-        keyContentProvider.showKey(sampleParsedRedisResource, 0, 'zset', 'mykey');
+        keyContentProvider.showKey(Shared.resourceWithKey, 0, 'zset', 'mykey');
 
         assert.rejects(keyContentProvider.provideTextDocumentContent(uri), Error);
     });

--- a/src/test/Shared.ts
+++ b/src/test/Shared.ts
@@ -1,0 +1,67 @@
+import { ParsedRedisResource } from '../../src-shared/ParsedRedisResource';
+import { ParsedAccessKeys } from '../../src-shared/ParsedAccessKeys';
+
+const accessKeys: ParsedAccessKeys = {
+    primaryKey: 'key1',
+    secondaryKey: 'key2',
+};
+
+export const resourceWithKey: ParsedRedisResource = {
+    resourceId:
+        '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res-group/providers/Microsoft.Cache/Redis/my-cache',
+    subscriptionId: '00000000-0000-0000-0000-000000000000',
+    resourceGroup: 'res-group',
+    name: 'my-cache',
+    hostName: 'my-cache.redis.cache.windows.net',
+    port: 6379,
+    enableNonSslPort: true,
+    sslPort: 6380,
+    sku: 'Premium P1',
+    location: 'East US',
+    redisVersion: '4.0.0',
+    provisioningState: 'Succeeded',
+    cluster: false,
+    shardCount: 0,
+    linkedServers: [],
+    accessKeys: Promise.resolve(accessKeys),
+};
+
+export const resourceWithKey2: ParsedRedisResource = {
+    resourceId:
+        '/subscriptions/11111111-0000-0000-0000-000000000000/resourceGroups/res-group/providers/Microsoft.Cache/Redis/my-cache',
+    subscriptionId: '11111111-0000-0000-0000-000000000000',
+    resourceGroup: 'res-group',
+    name: 'my-cache2',
+    hostName: 'mycache2.net',
+    enableNonSslPort: true,
+    port: 6379,
+    sslPort: 6380,
+    sku: 'Premium P1',
+    location: 'West US',
+    redisVersion: 'Unknown',
+    provisioningState: 'Unknown',
+    cluster: false,
+    shardCount: 0,
+    linkedServers: [],
+    accessKeys: Promise.resolve(accessKeys),
+};
+
+export const resourceWithoutKey: ParsedRedisResource = {
+    resourceId:
+        '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res-group/providers/Microsoft.Cache/Redis/my-cache',
+    subscriptionId: '00000000-0000-0000-0000-000000000000',
+    resourceGroup: 'res-group',
+    name: 'my-cache',
+    hostName: 'my-cache.redis.cache.windows.net',
+    port: 6379,
+    enableNonSslPort: true,
+    sslPort: 6380,
+    sku: 'Premium P1',
+    location: 'East US',
+    redisVersion: '4.0.0',
+    provisioningState: 'Succeeded',
+    cluster: false,
+    shardCount: 0,
+    linkedServers: [],
+    accessKeys: Promise.resolve(undefined),
+};

--- a/src/test/Shared.ts
+++ b/src/test/Shared.ts
@@ -6,7 +6,7 @@ const accessKeys: ParsedAccessKeys = {
     secondaryKey: 'key2',
 };
 
-export const resourceWithKey: ParsedRedisResource = {
+export const createResourceWithKey = (): ParsedRedisResource => ({
     resourceId:
         '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res-group/providers/Microsoft.Cache/Redis/my-cache',
     subscriptionId: '00000000-0000-0000-0000-000000000000',
@@ -24,9 +24,9 @@ export const resourceWithKey: ParsedRedisResource = {
     shardCount: 0,
     linkedServers: [],
     accessKeys: Promise.resolve(accessKeys),
-};
+});
 
-export const resourceWithKey2: ParsedRedisResource = {
+export const createResourceWithKey2 = (): ParsedRedisResource => ({
     resourceId:
         '/subscriptions/11111111-0000-0000-0000-000000000000/resourceGroups/res-group/providers/Microsoft.Cache/Redis/my-cache',
     subscriptionId: '11111111-0000-0000-0000-000000000000',
@@ -44,9 +44,9 @@ export const resourceWithKey2: ParsedRedisResource = {
     shardCount: 0,
     linkedServers: [],
     accessKeys: Promise.resolve(accessKeys),
-};
+});
 
-export const resourceWithoutKey: ParsedRedisResource = {
+export const createResourceWithoutKey = (): ParsedRedisResource => ({
     resourceId:
         '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res-group/providers/Microsoft.Cache/Redis/my-cache',
     subscriptionId: '00000000-0000-0000-0000-000000000000',
@@ -64,4 +64,4 @@ export const resourceWithoutKey: ParsedRedisResource = {
     shardCount: 0,
     linkedServers: [],
     accessKeys: Promise.resolve(undefined),
-};
+});

--- a/src/test/clients/RedisClient.test.ts
+++ b/src/test/clients/RedisClient.test.ts
@@ -3,7 +3,7 @@
 
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { ParsedRedisResource } from '../../../src-shared/ParsedRedisResource';
+import * as Shared from '../Shared';
 import { TestRedisClient } from './TestRedisClient';
 
 describe('RedisClient', () => {
@@ -21,79 +21,16 @@ describe('RedisClient', () => {
         sandbox.restore();
     });
 
-    // A sample Redis resource for which the user does not have write access
-    const sampleParsedRedisResourceMissingKeys: ParsedRedisResource = {
-        resourceId:
-            '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res-group/providers/Microsoft.Cache/Redis/my-cache',
-        subscriptionId: '00000000-0000-0000-0000-000000000000',
-        resourceGroup: 'res-group',
-        name: 'my-cache',
-        hostName: 'mycache.net',
-        enableNonSslPort: true,
-        port: 6379,
-        sslPort: 6380,
-        sku: 'Premium P1',
-        location: 'West US',
-        redisVersion: 'Unknown',
-        provisioningState: 'Unknown',
-        cluster: false,
-        shardCount: 0,
-        linkedServers: [],
-        accessKey: Promise.resolve(undefined),
-    };
-
-    // A sample Redis resource for which the user has read and write access
-    const sampleParsedRedisResource: ParsedRedisResource = {
-        resourceId:
-            '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res-group/providers/Microsoft.Cache/Redis/my-cache',
-        subscriptionId: '00000000-0000-0000-0000-000000000000',
-        resourceGroup: 'res-group',
-        name: 'my-cache',
-        hostName: 'mycache.net',
-        enableNonSslPort: true,
-        port: 6379,
-        sslPort: 6380,
-        sku: 'Premium P1',
-        location: 'West US',
-        redisVersion: 'Unknown',
-        provisioningState: 'Unknown',
-        cluster: false,
-        shardCount: 0,
-        linkedServers: [],
-        accessKey: Promise.resolve('key'),
-    };
-
-    // Another sample Redis resource for which the user has read and write access
-    const sampleParsedRedisResource2: ParsedRedisResource = {
-        resourceId:
-            '/subscriptions/11111111-0000-0000-0000-000000000000/resourceGroups/res-group/providers/Microsoft.Cache/Redis/my-cache',
-        subscriptionId: '11111111-0000-0000-0000-000000000000',
-        resourceGroup: 'res-group',
-        name: 'my-cache2',
-        hostName: 'mycache2.net',
-        enableNonSslPort: true,
-        port: 6379,
-        sslPort: 6380,
-        sku: 'Premium P1',
-        location: 'West US',
-        redisVersion: 'Unknown',
-        provisioningState: 'Unknown',
-        cluster: false,
-        shardCount: 0,
-        linkedServers: [],
-        accessKey: Promise.resolve('key'),
-    };
-
     describe('connectToRedisResource', () => {
         it('should attempt to connect to the Redis cache if given valid parameters', async () => {
             // Setup TestRedisClient stubs
             TestRedisClient.setup();
 
-            await TestRedisClient.connectToRedisResource(sampleParsedRedisResource);
+            await TestRedisClient.connectToRedisResource(Shared.resourceWithKey);
             assert.strictEqual(TestRedisClient.connectCalled, 1);
 
             // Try connecting to different cache
-            await TestRedisClient.connectToRedisResource(sampleParsedRedisResource2);
+            await TestRedisClient.connectToRedisResource(Shared.resourceWithKey2);
             assert.strictEqual(TestRedisClient.connectCalled, 2);
         });
 
@@ -101,11 +38,11 @@ describe('RedisClient', () => {
             // Setup TestRedisClient stubs
             TestRedisClient.setup();
 
-            await TestRedisClient.connectToRedisResource(sampleParsedRedisResource);
+            await TestRedisClient.connectToRedisResource(Shared.resourceWithKey);
             assert.strictEqual(TestRedisClient.connectCalled, 1);
 
             // Try connecting again
-            await TestRedisClient.connectToRedisResource(sampleParsedRedisResource);
+            await TestRedisClient.connectToRedisResource(Shared.resourceWithKey);
             assert.strictEqual(TestRedisClient.connectCalled, 1);
         });
 
@@ -113,7 +50,7 @@ describe('RedisClient', () => {
             // Setup TestRedisClient stubs
             TestRedisClient.setup();
 
-            const promise = TestRedisClient.connectToRedisResource(sampleParsedRedisResourceMissingKeys);
+            const promise = TestRedisClient.connectToRedisResource(Shared.resourceWithoutKey);
 
             assert.rejects(promise, Error);
             assert.strictEqual(TestRedisClient.connectCalled, 0);
@@ -122,7 +59,7 @@ describe('RedisClient', () => {
 
     describe('Redis commands', () => {
         it('should return proper values when connected to cache', async () => {
-            const client = await TestRedisClient.connectToRedisResource(sampleParsedRedisResource);
+            const client = await TestRedisClient.connectToRedisResource(Shared.resourceWithKey);
 
             TestRedisClient.stubExecResponse('someValue');
             assert.strictEqual(await client.get('someKey', 0), 'someValue');

--- a/src/test/clients/RedisClient.test.ts
+++ b/src/test/clients/RedisClient.test.ts
@@ -26,11 +26,11 @@ describe('RedisClient', () => {
             // Setup TestRedisClient stubs
             TestRedisClient.setup();
 
-            await TestRedisClient.connectToRedisResource(Shared.resourceWithKey);
+            await TestRedisClient.connectToRedisResource(Shared.createResourceWithKey());
             assert.strictEqual(TestRedisClient.connectCalled, 1);
 
             // Try connecting to different cache
-            await TestRedisClient.connectToRedisResource(Shared.resourceWithKey2);
+            await TestRedisClient.connectToRedisResource(Shared.createResourceWithKey2());
             assert.strictEqual(TestRedisClient.connectCalled, 2);
         });
 
@@ -38,11 +38,11 @@ describe('RedisClient', () => {
             // Setup TestRedisClient stubs
             TestRedisClient.setup();
 
-            await TestRedisClient.connectToRedisResource(Shared.resourceWithKey);
+            await TestRedisClient.connectToRedisResource(Shared.createResourceWithKey());
             assert.strictEqual(TestRedisClient.connectCalled, 1);
 
             // Try connecting again
-            await TestRedisClient.connectToRedisResource(Shared.resourceWithKey);
+            await TestRedisClient.connectToRedisResource(Shared.createResourceWithKey());
             assert.strictEqual(TestRedisClient.connectCalled, 1);
         });
 
@@ -50,7 +50,7 @@ describe('RedisClient', () => {
             // Setup TestRedisClient stubs
             TestRedisClient.setup();
 
-            const promise = TestRedisClient.connectToRedisResource(Shared.resourceWithoutKey);
+            const promise = TestRedisClient.connectToRedisResource(Shared.createResourceWithoutKey());
 
             assert.rejects(promise, Error);
             assert.strictEqual(TestRedisClient.connectCalled, 0);
@@ -59,7 +59,7 @@ describe('RedisClient', () => {
 
     describe('Redis commands', () => {
         it('should return proper values when connected to cache', async () => {
-            const client = await TestRedisClient.connectToRedisResource(Shared.resourceWithKey);
+            const client = await TestRedisClient.connectToRedisResource(Shared.createResourceWithKey());
 
             TestRedisClient.stubExecResponse('someValue');
             assert.strictEqual(await client.get('someKey', 0), 'someValue');

--- a/src/test/clients/RedisResourceClient.test.ts
+++ b/src/test/clients/RedisResourceClient.test.ts
@@ -66,7 +66,7 @@ describe('RedisResourceClient', () => {
             const resourceList = await redisResourceClient.listResources();
 
             assert.strictEqual(resourceList.length, 1);
-            assert.deepStrictEqual(resourceList[0], Shared.resourceWithKey);
+            assert.deepStrictEqual(resourceList[0], Shared.createResourceWithKey());
             assert.strictEqual(resourceList.nextLink, 'someLink');
             assert(stubbedRedis.list.calledOnce);
             assert(stubbedRedis.listKeys.calledOnce);
@@ -127,7 +127,7 @@ describe('RedisResourceClient', () => {
             const resourceList = await redisResourceClient.listNextResources('link');
 
             assert.strictEqual(resourceList.length, 1);
-            assert.deepStrictEqual(resourceList[0], Shared.resourceWithKey);
+            assert.deepStrictEqual(resourceList[0], Shared.createResourceWithKey());
             assert.strictEqual(resourceList.nextLink, undefined);
             assert(stubbedRedis.listNext.calledOnce);
             assert(stubbedRedis.listKeys.calledOnce);
@@ -252,7 +252,7 @@ describe('RedisResourceClient', () => {
             const redisResourceClient = new RedisResourceClient(rmClient);
             const parsedResource = await redisResourceClient.getRedisResourceByName('res-group', 'name');
 
-            assert.deepStrictEqual(parsedResource, Shared.resourceWithKey);
+            assert.deepStrictEqual(parsedResource, Shared.createResourceWithKey());
             assert(stubbedRedis.get.calledOnce);
         });
 
@@ -294,7 +294,7 @@ describe('RedisResourceClient', () => {
             const redisResourceClient = new RedisResourceClient(rmClient);
             const parsedResource = await redisResourceClient.getRedisResourceByName('res-group', 'name');
 
-            assert.deepStrictEqual(parsedResource, Shared.resourceWithKey);
+            assert.deepStrictEqual(parsedResource, Shared.createResourceWithKey());
             assert(stubbedRedis.get.calledOnce);
         });
 

--- a/src/test/utils/ResourceUtils.test.ts
+++ b/src/test/utils/ResourceUtils.test.ts
@@ -2,62 +2,24 @@
 // Licensed under the MIT License.
 
 import * as assert from 'assert';
-import { ParsedRedisResource } from '../../../src-shared/ParsedRedisResource';
-import { getConnectionString } from '../../utils/ResourceUtils';
+import { getConnectionStrings } from '../../utils/ResourceUtils';
+import * as Shared from '../Shared';
+import { ParsedConnectionStrings } from '../../../src-shared/ParsedConnectionStrings';
 
 describe('ResourceUtils', () => {
     describe('getConnectionString', () => {
         it('should properly return connection string for resource with access key', async () => {
-            const parsedRedisResource: ParsedRedisResource = {
-                resourceId:
-                    '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res-group/providers/Microsoft.Cache/Redis/my-cache',
-                subscriptionId: '00000000-0000-0000-0000-000000000000',
-                resourceGroup: 'res-group',
-                name: 'my-cache',
-                hostName: 'my-cache.redis.cache.windows.net',
-                port: 6379,
-                enableNonSslPort: true,
-                sslPort: 6380,
-                sku: 'P1 Premium',
-                location: 'East US',
-                redisVersion: '4.0.0',
-                provisioningState: 'Succeeded',
-                cluster: false,
-                shardCount: 0,
-                linkedServers: [],
-                accessKey: Promise.resolve('key'),
+            const expectedConnectionStrings: ParsedConnectionStrings = {
+                primaryConnectionString:
+                    'my-cache.redis.cache.windows.net:6380,password=key1,ssl=True,abortConnect=False',
+                secondaryConnectionString:
+                    'my-cache.redis.cache.windows.net:6380,password=key2,ssl=True,abortConnect=False',
             };
-
-            assert.strictEqual(
-                await getConnectionString(parsedRedisResource),
-                'my-cache.redis.cache.windows.net:6380,password=key,ssl=True,abortConnect=False'
-            );
+            assert.deepStrictEqual(await getConnectionStrings(Shared.resourceWithKey), expectedConnectionStrings);
         });
 
         it('should return undefined if resource does not have access key', async () => {
-            const parsedRedisResource: ParsedRedisResource = {
-                resourceId:
-                    '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res-group/providers/Microsoft.Cache/Redis/my-cache',
-                subscriptionId: '00000000-0000-0000-0000-000000000000',
-                resourceGroup: 'res-group',
-                name: 'my-cache',
-                hostName: 'my-cache.redis.cache.windows.net',
-                port: 6379,
-                enableNonSslPort: true,
-                sslPort: 6380,
-                sku: 'P1 Premium',
-                location: 'East US',
-                redisVersion: '4.0.0',
-                provisioningState: 'Succeeded',
-                cluster: false,
-                shardCount: 0,
-                linkedServers: [],
-                accessKey: Promise.resolve(undefined),
-            };
-
-            assert.strictEqual(await getConnectionString(parsedRedisResource), undefined);
-            parsedRedisResource.accessKey = Promise.resolve('');
-            assert.strictEqual(await getConnectionString(parsedRedisResource), undefined);
+            assert.strictEqual(await getConnectionStrings(Shared.resourceWithoutKey), undefined);
         });
     });
 });

--- a/src/test/utils/ResourceUtils.test.ts
+++ b/src/test/utils/ResourceUtils.test.ts
@@ -15,11 +15,14 @@ describe('ResourceUtils', () => {
                 secondaryConnectionString:
                     'my-cache.redis.cache.windows.net:6380,password=key2,ssl=True,abortConnect=False',
             };
-            assert.deepStrictEqual(await getConnectionStrings(Shared.resourceWithKey), expectedConnectionStrings);
+            assert.deepStrictEqual(
+                await getConnectionStrings(Shared.createResourceWithKey()),
+                expectedConnectionStrings
+            );
         });
 
         it('should return undefined if resource does not have access key', async () => {
-            assert.strictEqual(await getConnectionStrings(Shared.resourceWithoutKey), undefined);
+            assert.strictEqual(await getConnectionStrings(Shared.createResourceWithoutKey()), undefined);
         });
     });
 });

--- a/src/test/utils/UriUtils.test.ts
+++ b/src/test/utils/UriUtils.test.ts
@@ -7,11 +7,9 @@ import { createKeyContentUri, decodeUri } from '../../utils/UriUtils';
 import * as Shared from '../Shared';
 
 describe('URI Utils', () => {
-    const hostName = 'my-cache.redis.cache.windows.net';
-
     describe('createKeyContentUri', () => {
         it('should properly encode given parameters', () => {
-            const uri = createKeyContentUri(Shared.resourceWithKey, 12, 'zset', 'mykey', 'subkey', 'altsubkey');
+            const uri = createKeyContentUri(Shared.createResourceWithKey(), 12, 'zset', 'mykey', 'subkey', 'altsubkey');
             assert.strictEqual(
                 uri.query,
                 'payload=eyJyZXNvdXJjZUlkIjoiL3N1YnNjcmlwdGlvbnMvMDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwL3Jlc291cmNlR3JvdXBzL3Jlcy1ncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0LkNhY2hlL1JlZGlzL215LWNhY2hlIiwiZGIiOjEyLCJ0eXBlIjoienNldCIsImtleSI6Im15a2V5Iiwic3Via2V5Ijoic3Via2V5In0%3D'
@@ -19,36 +17,36 @@ describe('URI Utils', () => {
         });
 
         it('should sanitize URI path', () => {
-            const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'string', 'a#b? c/d\\e');
+            const uri = createKeyContentUri(Shared.createResourceWithKey(), 0, 'string', 'a#b? c/d\\e');
             assert.strictEqual(uri.path, 'my-cache.redis.cache.windows.net/a_b_ c_d_e');
         });
 
         it('should generate valid URI for strings', () => {
-            const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'string', 'mykey');
+            const uri = createKeyContentUri(Shared.createResourceWithKey(), 0, 'string', 'mykey');
             assert.strictEqual(uri.path, 'my-cache.redis.cache.windows.net/mykey');
             assert.strictEqual(uri.scheme, 'azureCache');
         });
 
         it('should generate valid URI for lists', () => {
-            const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'list', 'mykey', '10');
+            const uri = createKeyContentUri(Shared.createResourceWithKey(), 0, 'list', 'mykey', '10');
             assert.strictEqual(uri.path, 'my-cache.redis.cache.windows.net/mykey[10]');
             assert.strictEqual(uri.scheme, 'azureCache');
         });
 
         it('should generate valid URI for sets', () => {
-            const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'set', 'mykey', '10');
+            const uri = createKeyContentUri(Shared.createResourceWithKey(), 0, 'set', 'mykey', '10');
             assert.strictEqual(uri.path, 'my-cache.redis.cache.windows.net/mykey[10]');
             assert.strictEqual(uri.scheme, 'azureCache');
         });
 
         it('should generate valid URI for hashes', () => {
-            const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'hash', 'mykey', 'hashfield');
+            const uri = createKeyContentUri(Shared.createResourceWithKey(), 0, 'hash', 'mykey', 'hashfield');
             assert.strictEqual(uri.path, 'my-cache.redis.cache.windows.net/mykey[hashfield]');
             assert.strictEqual(uri.scheme, 'azureCache');
         });
 
         it('should generate valid URI for sorted sets', () => {
-            const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'zset', 'mykey', '5', '-100');
+            const uri = createKeyContentUri(Shared.createResourceWithKey(), 0, 'zset', 'mykey', '5', '-100');
             assert.strictEqual(uri.path, 'my-cache.redis.cache.windows.net/mykey[-100]');
             assert.strictEqual(uri.scheme, 'azureCache');
         });

--- a/src/test/utils/UriUtils.test.ts
+++ b/src/test/utils/UriUtils.test.ts
@@ -3,34 +3,15 @@
 
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { ParsedRedisResource } from '../../../src-shared/ParsedRedisResource';
 import { createKeyContentUri, decodeUri } from '../../utils/UriUtils';
+import * as Shared from '../Shared';
 
 describe('URI Utils', () => {
     const hostName = 'my-cache.redis.cache.windows.net';
-    const parsedRedisResource: ParsedRedisResource = {
-        resourceId:
-            '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/res-group/providers/Microsoft.Cache/Redis/my-cache',
-        subscriptionId: '00000000-0000-0000-0000-000000000000',
-        resourceGroup: 'res-group',
-        name: 'my-cache',
-        hostName,
-        port: 6379,
-        enableNonSslPort: true,
-        sslPort: 6380,
-        sku: 'P1 Premium',
-        location: 'East US',
-        redisVersion: '4.0.0',
-        provisioningState: 'Succeeded',
-        cluster: false,
-        shardCount: 0,
-        linkedServers: [],
-        accessKey: Promise.resolve('key'),
-    };
 
     describe('createKeyContentUri', () => {
         it('should properly encode given parameters', () => {
-            const uri = createKeyContentUri(parsedRedisResource, 12, 'zset', 'mykey', 'subkey', 'altsubkey');
+            const uri = createKeyContentUri(Shared.resourceWithKey, 12, 'zset', 'mykey', 'subkey', 'altsubkey');
             assert.strictEqual(
                 uri.query,
                 'payload=eyJyZXNvdXJjZUlkIjoiL3N1YnNjcmlwdGlvbnMvMDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwL3Jlc291cmNlR3JvdXBzL3Jlcy1ncm91cC9wcm92aWRlcnMvTWljcm9zb2Z0LkNhY2hlL1JlZGlzL215LWNhY2hlIiwiZGIiOjEyLCJ0eXBlIjoienNldCIsImtleSI6Im15a2V5Iiwic3Via2V5Ijoic3Via2V5In0%3D'
@@ -38,36 +19,36 @@ describe('URI Utils', () => {
         });
 
         it('should sanitize URI path', () => {
-            const uri = createKeyContentUri(parsedRedisResource, 0, 'string', 'a#b? c/d\\e');
+            const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'string', 'a#b? c/d\\e');
             assert.strictEqual(uri.path, 'my-cache.redis.cache.windows.net/a_b_ c_d_e');
         });
 
         it('should generate valid URI for strings', () => {
-            const uri = createKeyContentUri(parsedRedisResource, 0, 'string', 'mykey');
+            const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'string', 'mykey');
             assert.strictEqual(uri.path, 'my-cache.redis.cache.windows.net/mykey');
             assert.strictEqual(uri.scheme, 'azureCache');
         });
 
         it('should generate valid URI for lists', () => {
-            const uri = createKeyContentUri(parsedRedisResource, 0, 'list', 'mykey', '10');
+            const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'list', 'mykey', '10');
             assert.strictEqual(uri.path, 'my-cache.redis.cache.windows.net/mykey[10]');
             assert.strictEqual(uri.scheme, 'azureCache');
         });
 
         it('should generate valid URI for sets', () => {
-            const uri = createKeyContentUri(parsedRedisResource, 0, 'set', 'mykey', '10');
+            const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'set', 'mykey', '10');
             assert.strictEqual(uri.path, 'my-cache.redis.cache.windows.net/mykey[10]');
             assert.strictEqual(uri.scheme, 'azureCache');
         });
 
         it('should generate valid URI for hashes', () => {
-            const uri = createKeyContentUri(parsedRedisResource, 0, 'hash', 'mykey', 'hashfield');
+            const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'hash', 'mykey', 'hashfield');
             assert.strictEqual(uri.path, 'my-cache.redis.cache.windows.net/mykey[hashfield]');
             assert.strictEqual(uri.scheme, 'azureCache');
         });
 
         it('should generate valid URI for sorted sets', () => {
-            const uri = createKeyContentUri(parsedRedisResource, 0, 'zset', 'mykey', '5', '-100');
+            const uri = createKeyContentUri(Shared.resourceWithKey, 0, 'zset', 'mykey', '5', '-100');
             assert.strictEqual(uri.path, 'my-cache.redis.cache.windows.net/mykey[-100]');
             assert.strictEqual(uri.scheme, 'azureCache');
         });

--- a/src/tree/azure/AzureCacheItem.ts
+++ b/src/tree/azure/AzureCacheItem.ts
@@ -158,8 +158,20 @@ export class AzureCacheItem extends AzureParentTreeItem implements FilterParentI
         this.webview.reveal(this.parsedRedisResource.name, this.parsedRedisResource);
     }
 
-    public async getConnectionString(): Promise<string | undefined> {
-        return ResourceUtils.getConnectionString(this.parsedRedisResource);
+    public async getPrimaryAccessKey(): Promise<string | undefined> {
+        return (await this.parsedRedisResource.accessKeys)?.primaryKey;
+    }
+
+    public async getSecondaryAccessKey(): Promise<string | undefined> {
+        return (await this.parsedRedisResource.accessKeys)?.secondaryKey;
+    }
+
+    public async getPrimaryConnectionString(): Promise<string | undefined> {
+        return (await ResourceUtils.getConnectionStrings(this.parsedRedisResource))?.primaryConnectionString;
+    }
+
+    public async getSecondaryConnectionString(): Promise<string | undefined> {
+        return (await ResourceUtils.getConnectionStrings(this.parsedRedisResource))?.secondaryConnectionString;
     }
 
     public disposeWebview(): void {

--- a/src/utils/ResourceUtils.ts
+++ b/src/utils/ResourceUtils.ts
@@ -2,19 +2,25 @@
 // Licensed under the MIT License.
 
 import { ParsedRedisResource } from '../../src-shared/ParsedRedisResource';
+import { ParsedConnectionStrings } from '../../src-shared/ParsedConnectionStrings';
 
 /**
- * Returns StackExchange.Redis connection string.
+ * Returns primary and secondary StackExchange.Redis connection strings.
  *
- * @param parsedRedisResource The Redis resource.
- * @param accessKey The access key/password
+ * @param parsedRedisResource The Redis resource
  */
-export async function getConnectionString(parsedRedisResource: ParsedRedisResource): Promise<string | undefined> {
-    const accessKey = await parsedRedisResource.accessKey;
-    if (!accessKey) {
+export async function getConnectionStrings(
+    parsedRedisResource: ParsedRedisResource
+): Promise<ParsedConnectionStrings | undefined> {
+    const accessKeys = await parsedRedisResource.accessKeys;
+    if (typeof accessKeys === 'undefined') {
         return undefined;
     }
 
     const { hostName, sslPort } = parsedRedisResource;
-    return `${hostName}:${sslPort},password=${accessKey},ssl=True,abortConnect=False`;
+    const { primaryKey, secondaryKey } = accessKeys;
+    return {
+        primaryConnectionString: `${hostName}:${sslPort},password=${primaryKey},ssl=True,abortConnect=False`,
+        secondaryConnectionString: `${hostName}:${sslPort},password=${secondaryKey},ssl=True,abortConnect=False`,
+    } as ParsedConnectionStrings;
 }

--- a/src/webview/CachePropsWebview.ts
+++ b/src/webview/CachePropsWebview.ts
@@ -6,7 +6,6 @@ import { ParsedRedisResource } from '../../src-shared/ParsedRedisResource';
 import { WebviewCommand } from '../../src-shared/WebviewCommand';
 import { WebviewMessage } from '../../src-shared/WebviewMessage';
 import { WebviewView } from '../../src-shared/WebviewView';
-import { getConnectionString } from '../utils/ResourceUtils';
 import { BaseWebview } from './BaseWebview';
 
 /**
@@ -44,7 +43,6 @@ export class CachePropsWebview extends BaseWebview {
     protected async sendData(parsedRedisResource: ParsedRedisResource): Promise<void> {
         this.postMessage(WebviewCommand.View, WebviewView.CacheProperties);
         this.postMessage(WebviewCommand.ParsedRedisResource, parsedRedisResource);
-        this.postMessage(WebviewCommand.AccessKey, await parsedRedisResource.accessKey);
-        this.postMessage(WebviewCommand.ConnectionString, await getConnectionString(parsedRedisResource));
+        this.postMessage(WebviewCommand.AccessKeys, await parsedRedisResource.accessKeys);
     }
 }


### PR DESCRIPTION
Closes #23 

### Changes

- Show primary and secondary access keys and connection strings in cache properties
- Add context menu entries for copying primary and secondary access keys and connection strings
- Refactor tests (new `Shared` module for reusing `ParsedRedisResource` instances across tests)

### Screenshots
**Context menu:**
<img width="437" alt="Screen Shot 2020-08-15 at 10 26 31 PM" src="https://user-images.githubusercontent.com/9157833/90325237-15d25780-df47-11ea-8d1a-2a344e1954c0.png">


**Cache properties:**
<img width="1098" alt="Screen Shot 2020-08-15 at 10 25 49 PM" src="https://user-images.githubusercontent.com/9157833/90325239-1a970b80-df47-11ea-9741-b89227ed5a8b.png">

**Access key dropdown (expanded):**
<img width="1038" alt="Screen Shot 2020-08-15 at 10 26 10 PM" src="https://user-images.githubusercontent.com/9157833/90325244-271b6400-df47-11ea-857b-b8ce46073986.png">
